### PR TITLE
Cleanup UI Analyzer Warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,9 @@
 
     "al.codeAnalyzers": [
       "${CodeCop}",
-      "${UICop}"
+      "${UICop}", 
+      "${PerTenantExtensionCop}",
+      "${AppSourceCop}"
     ],
     "al.enableCodeAnalysis": true,
     "al.enableCodeActions": true,
@@ -12,5 +14,6 @@
         "CRS.OnSaveAlFileAction": "Reorganize",
         "CRS.RenameWithGit": false,
         "CRS.ObjectNamePrefix": "SPBPL ",
+        "al.ruleSetPath": "./ruleset.json",
 
 }

--- a/app.json
+++ b/app.json
@@ -30,5 +30,6 @@
   "runtime": "8.0",
   "features": [
     "TranslationFile", "NoImplicitWith"
-  ]
+  ],
+  "applicationInsightsConnectionString": ""
 }

--- a/ruleset.json
+++ b/ruleset.json
@@ -1,0 +1,21 @@
+{
+    "name": "Project ruleset",
+    "description": "A list of company specific rules",
+    "rules": [
+        {
+            "id": "PTE0001",
+            "action": "None",
+            "justification": "<object> has an ID of [#######]. It must be between 50000 and 99999. Need to clarify licensing issues with VAR ID range"
+        },
+        {
+            "id": "PTE0002",
+            "action": "None",
+            "justification": "<field in tableextension> has an ID of [#######]. It must be between 50000 and 99999. Need to clarify licensing issues with VAR ID range"
+        },
+        {
+            "id": "AS0084",
+            "action": "None",
+            "justification": "Not Applicable - The ID range '[50000..99999]' is not valid. It must be within the range allocated to the partner for AppSource, within the range '[1000000..75999999]' allocated to AppSource applications, and outside the range '[50000..99999]' allocated to per-tenant customizations."
+        }
+    ]
+}

--- a/src/codeunit/SPBPLExtensionRegistration.Codeunit.al
+++ b/src/codeunit/SPBPLExtensionRegistration.Codeunit.al
@@ -17,15 +17,15 @@ codeunit 71034 "SPBPL Extension Registration"
         forceUpdate: Boolean)
     var
         SPBPLExtensionLicense: Record "SPBPL Extension License";
-        SPBLicenseManagement: Codeunit "SPBPL License Management";
-        SPBIsoStoreManager: Codeunit "SPBPL IsoStore Manager";
+        SPBPLLicenseManagement: Codeunit "SPBPL License Management";
+        SPBPLIsoStoreManager: Codeunit "SPBPL IsoStore Manager";
         EnvironmentInformation: Codeunit "Environment Information";
         PlusDaysTok: Label '<+%1D>', Comment = '%1 is the number of days ';
         GraceEndDate: Date;
         GraceDays: Integer;
     begin
         if minimumLicensingAppVersion > Version.Create('1.0.0.0') then
-            SPBLicenseManagement.CheckSupportedVersion(minimumLicensingAppVersion);
+            SPBPLLicenseManagement.CheckSupportedVersion(minimumLicensingAppVersion);
 
         if EnvironmentInformation.IsOnPrem() or EnvironmentInformation.IsProduction() then
             GraceDays := daysAllowedBeforeActivationProd
@@ -60,25 +60,25 @@ codeunit 71034 "SPBPL Extension Registration"
             SPBPLExtensionLicense."Trial Grace End Date" := GraceEndDate;
             SPBPLExtensionLicense.Insert();
         end;
-        SPBIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'installDate', Format(CurrentDateTime, 0, 9));
-        SPBIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'preactivationDays', Format(GraceDays));
+        SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'installDate', Format(CurrentDateTime, 0, 9));
+        SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'preactivationDays', Format(GraceDays));
     end;
 
     procedure CheckIfActive(AppId: Guid; InactiveShowError: Boolean): Boolean
     var
-        SPBExtensionLicense: Record "SPBPL Extension License";
-        SPBLicenseManagement: Codeunit "SPBPL License Management";
+        SPBPLExtensionLicense: Record "SPBPL Extension License";
+        SPBPLLicenseManagement: Codeunit "SPBPL License Management";
         NoSubFoundErr: Label 'No Subscription was found in the Subscriptions list for AppId: %1', Comment = '%1 is which Application ID';
         SubscriptionInactiveErr: Label 'The Subscription for %1 is not Active.  Contact your system administrator to re-activate it.', Comment = '%1 is the name of the Subscription';
         IsActive: Boolean;
     begin
-        if not SPBExtensionLicense.get(AppId) then
+        if not SPBPLExtensionLicense.get(AppId) then
             if GuiAllowed() then
                 Error(NoSubFoundErr, AppId);
-        IsActive := SPBLicenseManagement.CheckIfActive(SPBExtensionLicense);
+        IsActive := SPBPLLicenseManagement.CheckIfActive(SPBPLExtensionLicense);
         if not IsActive and InactiveShowError then
             if GuiAllowed() then
-                Error(SubscriptionInactiveErr, SPBExtensionLicense."Extension Name");
+                Error(SubscriptionInactiveErr, SPBPLExtensionLicense."Extension Name");
         exit(IsActive);
     end;
 }

--- a/src/codeunit/SPBPLGumroadCommunicator.Codeunit.al
+++ b/src/codeunit/SPBPLGumroadCommunicator.Codeunit.al
@@ -4,7 +4,7 @@ codeunit 71035 "SPBPL Gumroad Communicator" implements "SPBPL ILicenseCommunicat
     var
         GumroadVerifyAPITok: Label 'https://api.gumroad.com/v2/licenses/verify?product_permalink=%1&license_key=%2&increment_uses_count=%3', Comment = '%1 %2 %3';
 
-    procedure CallAPIForVerification(var SPBExtensionLicense: Record "SPBPL Extension License"; var ResponseBody: Text; IncrementLicenseCount: Boolean) ResultOK: Boolean
+    procedure CallAPIForVerification(var SPBPLExtensionLicense: Record "SPBPL Extension License"; var ResponseBody: Text; IncrementLicenseCount: Boolean) ResultOK: Boolean
     var
         NAVAppSetting: Record "NAV App Setting";
         ApiHttpClient: HttpClient;
@@ -28,7 +28,7 @@ codeunit 71035 "SPBPL Gumroad Communicator" implements "SPBPL ILicenseCommunicat
             NAVAppSetting.Insert();
         end;
 
-        VerifyAPI := StrSubstNo(GumroadVerifyAPITok, SPBExtensionLicense."Product Code", SPBExtensionLicense."License Key", Format(IncrementLicenseCount, 0, 9));
+        VerifyAPI := StrSubstNo(GumroadVerifyAPITok, SPBPLExtensionLicense."Product Code", SPBPLExtensionLicense."License Key", Format(IncrementLicenseCount, 0, 9));
         ApiHttpRequestMessage.SetRequestUri(VerifyAPI);
         ApiHttpRequestMessage.Method('POST');
 
@@ -49,14 +49,16 @@ codeunit 71035 "SPBPL Gumroad Communicator" implements "SPBPL ILicenseCommunicat
     end;
 
 
-    procedure ReportPossibleMisuse(SPBExtensionLicense: Record "SPBPL Extension License")
+    procedure ReportPossibleMisuse(SPBPLExtensionLicense: Record "SPBPL Extension License")
     begin
         // Potential future use of 'reporting' misuse attempts.   For example, someone programmatically changing the Subscription Record
 
-        OnAfterThrowPossibleMisuse(SPBExtensionLicense);
+        OnAfterThrowPossibleMisuse(SPBPLExtensionLicense);
     end;
 
-    procedure PopulateSubscriptionFromResponse(var SPBExtensionLicense: Record "SPBPL Extension License"; var ResponseBody: Text)
+#pragma warning disable AA0150 // TODO - Passed as "var" for the interface
+    procedure PopulateSubscriptionFromResponse(var SPBPLExtensionLicense: Record "SPBPL Extension License"; var ResponseBody: Text)
+#pragma warning restore AA0150
     var
         TempJsonBuffer: Record "JSON Buffer" temporary;
         TempPlaceholder: Text;
@@ -65,7 +67,7 @@ codeunit 71035 "SPBPL Gumroad Communicator" implements "SPBPL ILicenseCommunicat
         GumroadToken: JsonToken;
         ActivationFailureErr: Label 'An error occured validating the license.  Contact %1 for assistance', Comment = '%1 is the App Publisher';
     begin
-        NavApp.GetModuleInfo(SPBExtensionLicense."Entry Id", AppInfo);
+        NavApp.GetModuleInfo(SPBPLExtensionLicense."Entry Id", AppInfo);
         GumroadJson.ReadFrom(ResponseBody);
         GumroadJson.Get('success', GumroadToken);
         if not GumroadToken.AsValue().AsBoolean() then
@@ -76,25 +78,27 @@ codeunit 71035 "SPBPL Gumroad Communicator" implements "SPBPL ILicenseCommunicat
         TempJsonBuffer.ReadFromText(ResponseBody);
 
         // Update the current Subscription record
-        SPBExtensionLicense.Validate(Activated, true);
-        TempJsonBuffer.GetPropertyValue(SPBExtensionLicense."License Key", 'license_key');
+        SPBPLExtensionLicense.Validate(Activated, true);
+        TempJsonBuffer.GetPropertyValue(TempPlaceholder, 'license_key');
+        SPBPLExtensionLicense."License Key" := CopyStr(TempPlaceholder, 1, MaxStrLen(SPBPLExtensionLicense."License Key"));
         TempJsonBuffer.GetPropertyValue(TempPlaceholder, 'created_at');
-        Evaluate(SPBExtensionLicense."Created At", TempPlaceholder);
+        Evaluate(SPBPLExtensionLicense."Created At", TempPlaceholder);
         TempJsonBuffer.GetPropertyValue(TempPlaceholder, 'subscription_ended_at');
-        Evaluate(SPBExtensionLicense."Subscription Ended At", TempPlaceholder);
+        Evaluate(SPBPLExtensionLicense."Subscription Ended At", TempPlaceholder);
         TempJsonBuffer.GetPropertyValue(TempPlaceholder, 'subscription_cancelled_at');
-        Evaluate(SPBExtensionLicense."Subscription Cancelled At", TempPlaceholder);
+        Evaluate(SPBPLExtensionLicense."Subscription Cancelled At", TempPlaceholder);
         TempJsonBuffer.GetPropertyValue(TempPlaceholder, 'subscription_failed_at');
-        Evaluate(SPBExtensionLicense."Subscription Failed At", TempPlaceholder);
+        Evaluate(SPBPLExtensionLicense."Subscription Failed At", TempPlaceholder);
 
-        TempJsonBuffer.GetPropertyValue(SPBExtensionLicense."Subscription Email", 'email');
-        SPBExtensionLicense.CalculateEndDate();
+        TempJsonBuffer.GetPropertyValue(TempPlaceholder, 'email');
+        SPBPLExtensionLicense."Subscription Email" := CopyStr(TempPlaceholder, 1, MaxStrLen(SPBPLExtensionLicense."Subscription Email"));
+        SPBPLExtensionLicense.CalculateEndDate();
     end;
 
-    procedure CheckAPILicenseCount(var SPBExtensionLicense: Record "SPBPL Extension License"; ResponseBody: Text): Boolean
+    procedure CheckAPILicenseCount(var SPBPLExtensionLicense: Record "SPBPL Extension License"; ResponseBody: Text): Boolean
     var
         TempJsonBuffer: Record "JSON Buffer" temporary;
-        GumroadUtilities: Codeunit "SPBPL License Utilities";
+        GumroadSPBPLLicenseUtilities: Codeunit "SPBPL License Utilities";
         LicenseUses: Integer;
         LicenseCount: Integer;
         AppInfo: ModuleInfo;
@@ -103,13 +107,13 @@ codeunit 71035 "SPBPL Gumroad Communicator" implements "SPBPL ILicenseCommunicat
         GumroadErr: Label 'An error occured validating the license.  Contact %1 for assistance', Comment = '%1 is the App Publisher';
     begin
         // The 'Test' product, we never do a Count check on this application
-        if SPBExtensionLicense."Entry Id" = GumroadUtilities.GetTestProductAppId() then
+        if SPBPLExtensionLicense."Entry Id" = GumroadSPBPLLicenseUtilities.GetTestProductAppId() then
             exit(true);
 
         GumroadJson.ReadFrom(ResponseBody);
         GumroadJson.Get('success', GumroadToken);
         if not GumroadToken.AsValue().AsBoolean() then begin
-            NavApp.GetModuleInfo(SPBExtensionLicense."Entry Id", AppInfo);
+            NavApp.GetModuleInfo(SPBPLExtensionLicense."Entry Id", AppInfo);
             if GuiAllowed() then
                 Error(GumroadErr, AppInfo.Publisher);
         end;
@@ -130,7 +134,7 @@ codeunit 71035 "SPBPL Gumroad Communicator" implements "SPBPL ILicenseCommunicat
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterThrowPossibleMisuse(SPBExtensionLicense: Record "SPBPL Extension License")
+    local procedure OnAfterThrowPossibleMisuse(SPBPLExtensionLicense: Record "SPBPL Extension License")
     begin
     end;
 }

--- a/src/codeunit/SPBPLIsoStoreManager.Codeunit.al
+++ b/src/codeunit/SPBPLIsoStoreManager.Codeunit.al
@@ -3,33 +3,33 @@ codeunit 71038 "SPBPL IsoStore Manager"
     // Utility Codeunit
     var
         EnvironmentInformation: Codeunit "Environment Information";
-        CryptoManagement: Codeunit "Cryptography Management";
+        CryptographyManagement: Codeunit "Cryptography Management";
         NameMapTok: Label '%1-%2', Comment = '%1 %2';
 
-    internal procedure SetAppValue(SPBExtensionLicense: Record "SPBPL Extension License"; StoreName: Text; StoreValue: Text)
+    internal procedure SetAppValue(SPBPLExtensionLicense: Record "SPBPL Extension License"; StoreName: Text; StoreValue: Text)
     begin
-        if not IsolatedStorage.Contains(SPBExtensionLicense."Entry Id") then
-            IsolatedStorage.Set(SPBExtensionLicense."Entry Id", '', DataScope::Module);
+        if not IsolatedStorage.Contains(SPBPLExtensionLicense."Entry Id") then
+            IsolatedStorage.Set(SPBPLExtensionLicense."Entry Id", '', DataScope::Module);
 
         if EnvironmentInformation.IsOnPrem() then
-            if CryptoManagement.IsEncryptionEnabled() and CryptoManagement.IsEncryptionPossible() then
-                StoreValue := CryptoManagement.Encrypt(StoreValue)
+            if CryptographyManagement.IsEncryptionEnabled() and CryptographyManagement.IsEncryptionPossible() then
+                StoreValue := CryptographyManagement.Encrypt(StoreValue)
             else
                 if GuiAllowed() then
                     Error('To use Spare Brained Licensing On-Prem, Database Encryption must be enabled.');
 
-        IsolatedStorage.Set(StrSubstNo(NameMapTok, SPBExtensionLicense."Entry Id", StoreName), StoreValue, DataScope::Module);
+        IsolatedStorage.Set(StrSubstNo(NameMapTok, SPBPLExtensionLicense."Entry Id", StoreName), StoreValue, DataScope::Module);
     end;
 
-    internal procedure GetAppValue(SPBExtensionLicense: Record "SPBPL Extension License"; StoreName: Text) ReturnValue: Text
+    internal procedure GetAppValue(SPBPLExtensionLicense: Record "SPBPL Extension License"; StoreName: Text) ReturnValue: Text
     begin
-        IsolatedStorage.Get(StrSubstNo(NameMapTok, SPBExtensionLicense."Entry Id", StoreName), DataScope::Module, ReturnValue);
-        if EnvironmentInformation.IsOnPrem() and CryptoManagement.IsEncryptionEnabled() and CryptoManagement.IsEncryptionPossible() then
-            ReturnValue := CryptoManagement.Decrypt(ReturnValue);
+        IsolatedStorage.Get(StrSubstNo(NameMapTok, SPBPLExtensionLicense."Entry Id", StoreName), DataScope::Module, ReturnValue);
+        if EnvironmentInformation.IsOnPrem() and CryptographyManagement.IsEncryptionEnabled() and CryptographyManagement.IsEncryptionPossible() then
+            ReturnValue := CryptographyManagement.Decrypt(ReturnValue);
     end;
 
-    internal procedure ContainsAppValue(SPBExtensionLicense: Record "SPBPL Extension License"; StoreName: Text): Boolean
+    internal procedure ContainsAppValue(SPBPLExtensionLicense: Record "SPBPL Extension License"; StoreName: Text): Boolean
     begin
-        exit(IsolatedStorage.Contains(StrSubstNo(NameMapTok, SPBExtensionLicense."Entry Id", StoreName), DataScope::Module));
+        exit(IsolatedStorage.Contains(StrSubstNo(NameMapTok, SPBPLExtensionLicense."Entry Id", StoreName), DataScope::Module));
     end;
 }

--- a/src/codeunit/SPBPLLicenseManagement.Codeunit.al
+++ b/src/codeunit/SPBPLLicenseManagement.Codeunit.al
@@ -4,7 +4,7 @@ codeunit 71036 "SPBPL License Management"
 
     var
         /* GumroadCommunicator: Codeunit "SPBPL Gumroad Communicator"; */
-        LicenseUtilities: Codeunit "SPBPL License Utilities";
+        SPBPLLicenseUtilities: Codeunit "SPBPL License Utilities";
 
     internal procedure CheckSupportedVersion(minVersion: Version)
     var
@@ -18,46 +18,46 @@ codeunit 71036 "SPBPL License Management"
     end;
 
 
-    internal procedure ActivateFromWizard(var SPBExtensionLicense: Record "SPBPL Extension License"): Boolean
+    internal procedure ActivateFromWizard(var SPBPLExtensionLicense: Record "SPBPL Extension License"): Boolean
     var
         ResponseBody: Text;
         NoRemainingUsesErr: Label 'There are no remaining uses of that license key to assign to this installation.';
         LicensePlatform: Interface "SPBPL ILicenseCommunicator";
     begin
-        LicensePlatform := SPBExtensionLicense."License Platform";
+        LicensePlatform := SPBPLExtensionLicense."License Platform";
         // We call first WITHOUT incrementing the use count to check current use count
-        if LicensePlatform.CallAPIForVerification(SPBExtensionLicense, ResponseBody, false) then
-            if LicensePlatform.CheckAPILicenseCount(SPBExtensionLicense, ResponseBody) then
-                exit(ActivateExtension(SPBExtensionLicense, ResponseBody))
+        if LicensePlatform.CallAPIForVerification(SPBPLExtensionLicense, ResponseBody, false) then
+            if LicensePlatform.CheckAPILicenseCount(SPBPLExtensionLicense, ResponseBody) then
+                exit(ActivateExtension(SPBPLExtensionLicense, ResponseBody))
             else
                 if GuiAllowed() then
                     Error(NoRemainingUsesErr);
     end;
 
-    internal procedure LaunchActivation(var SPBExtensionLicense: Record "SPBPL Extension License")
+    internal procedure LaunchActivation(var SPBPLExtensionLicense: Record "SPBPL Extension License")
     var
-        SPBLicenseActivationWizard: Page "SPBPL License Activation";
+        SPBPLLicenseActivationWizard: Page "SPBPL License Activation";
     begin
-        Clear(SPBLicenseActivationWizard);
-        SPBExtensionLicense.SetRecFilter();
-        SPBLicenseActivationWizard.SetTableView(SPBExtensionLicense);
-        SPBLicenseActivationWizard.RunModal();
+        Clear(SPBPLLicenseActivationWizard);
+        SPBPLExtensionLicense.SetRecFilter();
+        SPBPLLicenseActivationWizard.SetTableView(SPBPLExtensionLicense);
+        SPBPLLicenseActivationWizard.RunModal();
     end;
 
-    internal procedure VerifyActiveLicense(var SPBExtensionLicense: Record "SPBPL Extension License")
+    internal procedure VerifyActiveLicense(var SPBPLExtensionLicense: Record "SPBPL Extension License")
     begin
-        if not SPBExtensionLicense.Activated then
+        if not SPBPLExtensionLicense.Activated then
             exit;
 
-        if not CheckIfActive(SPBExtensionLicense) then begin
-            SPBExtensionLicense.Validate(Activated, false);
-            SPBExtensionLicense.Modify();
+        if not CheckIfActive(SPBPLExtensionLicense) then begin
+            SPBPLExtensionLicense.Validate(Activated, false);
+            SPBPLExtensionLicense.Modify();
         end;
     end;
 
-    internal procedure CheckIfActive(var SPBExtensionLicense: Record "SPBPL Extension License"): Boolean
+    internal procedure CheckIfActive(var SPBPLExtensionLicense: Record "SPBPL Extension License"): Boolean
     var
-        SPBIsoStoreManager: Codeunit "SPBPL IsoStore Manager";
+        SPBPLIsoStoreManager: Codeunit "SPBPL IsoStore Manager";
         EnvironmentInformation: Codeunit "Environment Information";
         GraceExpiringMsg: Label 'Today is the last trial day for %1. Please purchase a License Key and Activate the subscription to continue use.', Comment = '%1 is the name of the Extension';
         DaysGraceTok: Label '<+%1D>', Comment = '%1 is the number of days';
@@ -70,12 +70,12 @@ codeunit 71036 "SPBPL License Management"
         IsoNumber: Integer;
         LicensePlatform: Interface "SPBPL ILicenseCommunicator";
     begin
-        LicensePlatform := SPBExtensionLicense."License Platform";
+        LicensePlatform := SPBPLExtensionLicense."License Platform";
 
         // if the subscription isn't active, check if we're in the 'grace' preinstall window, which always includes the first day of use
-        if not SPBExtensionLicense.Activated then begin
-            Evaluate(InstallDateTime, SPBIsoStoreManager.GetAppValue(SPBExtensionLicense, 'installDate'));
-            Evaluate(IsoNumber, SPBIsoStoreManager.GetAppValue(SPBExtensionLicense, 'preactivationDays'));
+        if not SPBPLExtensionLicense.Activated then begin
+            Evaluate(InstallDateTime, SPBPLIsoStoreManager.GetAppValue(SPBPLExtensionLicense, 'installDate'));
+            Evaluate(IsoNumber, SPBPLIsoStoreManager.GetAppValue(SPBPLExtensionLicense, 'preactivationDays'));
             if IsoNumber > 0 then
                 GraceEndDate := CalcDate(StrSubstNo(DaysGraceTok, IsoNumber), DT2Date(InstallDateTime))
             else
@@ -85,120 +85,120 @@ codeunit 71036 "SPBPL License Management"
                 else
                     GraceEndDate := Today;
             if (GraceEndDate = Today) and GuiAllowed then
-                Message(GraceExpiringMsg, SPBExtensionLicense."Extension Name");
+                Message(GraceExpiringMsg, SPBPLExtensionLicense."Extension Name");
             if GraceEndDate > Today then
                 exit(true);
         end;
 
-        Evaluate(LastCheckDateTime, SPBIsoStoreManager.GetAppValue(SPBExtensionLicense, 'lastCheckDate'));
+        Evaluate(LastCheckDateTime, SPBPLIsoStoreManager.GetAppValue(SPBPLExtensionLicense, 'lastCheckDate'));
         if ((Today() - DT2Date(LastCheckDateTime)) > 0) then begin
-            if LicensePlatform.CallAPIForVerification(SPBExtensionLicense, ResponseBody, false) then begin
+            if LicensePlatform.CallAPIForVerification(SPBPLExtensionLicense, ResponseBody, false) then begin
                 // This may update the End Dates - note: may or may not call .Modify
-                LicensePlatform.PopulateSubscriptionFromResponse(SPBExtensionLicense, ResponseBody);
-                SPBExtensionLicense.Modify();
+                LicensePlatform.PopulateSubscriptionFromResponse(SPBPLExtensionLicense, ResponseBody);
+                SPBPLExtensionLicense.Modify();
             end;
-            DoVersionCheck(SPBExtensionLicense);
-            SPBIsoStoreManager.SetAppValue(SPBExtensionLicense, 'lastCheckDate', Format(CurrentDateTime, 0, 9));
+            DoVersionCheck(SPBPLExtensionLicense);
+            SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'lastCheckDate', Format(CurrentDateTime, 0, 9));
         end;
 
         // if the subscription ran out
-        if (SPBExtensionLicense."Subscription End Date" < CurrentDateTime) and
-          (SPBExtensionLicense."Subscription End Date" <> 0DT)
+        if (SPBPLExtensionLicense."Subscription End Date" < CurrentDateTime) and
+          (SPBPLExtensionLicense."Subscription End Date" <> 0DT)
         then
             exit(false);
 
 
         // if the record version IS active, then let's crosscheck against isolated storage
-        Evaluate(IsoActive, SPBIsoStoreManager.GetAppValue(SPBExtensionLicense, 'active'));
+        Evaluate(IsoActive, SPBPLIsoStoreManager.GetAppValue(SPBPLExtensionLicense, 'active'));
         if not IsoActive then
-            LicensePlatform.ReportPossibleMisuse(SPBExtensionLicense);
+            LicensePlatform.ReportPossibleMisuse(SPBPLExtensionLicense);
 
         // Check Record end date against IsoStorage end date
-        Evaluate(IsoDatetime, SPBIsoStoreManager.GetAppValue(SPBExtensionLicense, 'endDate'));
+        Evaluate(IsoDatetime, SPBPLIsoStoreManager.GetAppValue(SPBPLExtensionLicense, 'endDate'));
         if IsoDatetime <> 0DT then
             // Only checking at the date level in case of time zone nonsense
-            if DT2Date(IsoDatetime) <> DT2Date(SPBExtensionLicense."Subscription End Date") then
-                LicensePlatform.ReportPossibleMisuse(SPBExtensionLicense);
+            if DT2Date(IsoDatetime) <> DT2Date(SPBPLExtensionLicense."Subscription End Date") then
+                LicensePlatform.ReportPossibleMisuse(SPBPLExtensionLicense);
 
         // Finally, all things checked out
         exit(true);
     end;
 
-    local procedure ActivateExtension(var SPBExtensionLicense: Record "SPBPL Extension License"; ResponseBody: Text): Boolean
+    local procedure ActivateExtension(var SPBPLExtensionLicense: Record "SPBPL Extension License"; ResponseBody: Text): Boolean
     var
         LicensePlatform: Interface "SPBPL ILicenseCommunicator";
         AppInfo: ModuleInfo;
         ActivationFailureErr: Label 'An error occured validating the license.  Contact %1 for assistance', Comment = '%1 is the App Publisher';
         LicenseKeyExpiredErr: Label 'The License Key provided has already expired due to a Subscription End.  Contact %1 for assistance', Comment = '%1 is the App Publisher';
     begin
-        NavApp.GetModuleInfo(SPBExtensionLicense."Entry Id", AppInfo);
+        NavApp.GetModuleInfo(SPBPLExtensionLicense."Entry Id", AppInfo);
 
         // Note we're swapping the ResponseBody to the 2nd API call with the new info from the API!
-        LicensePlatform := SPBExtensionLicense."License Platform";
-        if LicensePlatform.CallAPIForVerification(SPBExtensionLicense, ResponseBody, true) then begin
+        LicensePlatform := SPBPLExtensionLicense."License Platform";
+        if LicensePlatform.CallAPIForVerification(SPBPLExtensionLicense, ResponseBody, true) then begin
 
-            LicensePlatform.PopulateSubscriptionFromResponse(SPBExtensionLicense, ResponseBody);
+            LicensePlatform.PopulateSubscriptionFromResponse(SPBPLExtensionLicense, ResponseBody);
 
-            if (SPBExtensionLicense."Subscription End Date" <> 0DT) and
-              (SPBExtensionLicense."Subscription End Date" < CurrentDateTime)
+            if (SPBPLExtensionLicense."Subscription End Date" <> 0DT) and
+              (SPBPLExtensionLicense."Subscription End Date" < CurrentDateTime)
             then begin
-                SPBExtensionLicense.Activated := false;
-                SPBExtensionLicense.Modify();
+                SPBPLExtensionLicense.Activated := false;
+                SPBPLExtensionLicense.Modify();
                 Commit();
-                OnAfterActivationFailure(SPBExtensionLicense, AppInfo);
+                OnAfterActivationFailure(SPBPLExtensionLicense, AppInfo);
                 if GuiAllowed() then
                     Error(LicenseKeyExpiredErr, AppInfo.Publisher);
             end else begin
-                SPBExtensionLicense.Modify();
+                SPBPLExtensionLicense.Modify();
                 Commit();
-                OnAfterActivationSuccess(SPBExtensionLicense, AppInfo);
+                OnAfterActivationSuccess(SPBPLExtensionLicense, AppInfo);
             end;
 
             // Now pop the details into IsolatedStorage
-            LicenseUtilities.UpdateOrCreateIsoStorage(SPBExtensionLicense, ResponseBody);
-            exit(SPBExtensionLicense.Activated);
+            SPBPLLicenseUtilities.UpdateOrCreateIsoStorage(SPBPLExtensionLicense, ResponseBody);
+            exit(SPBPLExtensionLicense.Activated);
         end else
             if GuiAllowed() then
                 Error(ActivationFailureErr, AppInfo.Publisher);
     end;
 
-    internal procedure DoVersionCheck(var SPBExtensionLicense: Record "SPBPL Extension License")
+    internal procedure DoVersionCheck(var SPBPLExtensionLicense: Record "SPBPL Extension License")
     var
         UserTask: Record "User Task";
         SubjectTok: Label 'Update Extension: %1', Comment = '%1 is Extension Name';
         DocsTok: Label 'https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/administration/tenant-admin-center-manage-apps#get-an-overview-and-check-for-updates';
         ApiHttpClient: HttpClient;
-        ApiHttpReqMessage: HttpRequestMessage;
-        ApiHttpRespMessage: HttpResponseMessage;
+        ApiHttpRequestMessage: HttpRequestMessage;
+        ApiHttpResponseMessage: HttpResponseMessage;
         VersionResponseBody: Text;
         IsHandled: Boolean;
         LatestVersion: Version;
         AppInfo: ModuleInfo;
     begin
         NavApp.GetCurrentModuleInfo(AppInfo);
-        if SPBExtensionLicense."Version Check URL" = '' then
+        if SPBPLExtensionLicense."Version Check URL" = '' then
             exit;
 
-        ApiHttpReqMessage.SetRequestUri(SPBExtensionLicense."Version Check URL");
-        ApiHttpReqMessage.Method('GET');
+        ApiHttpRequestMessage.SetRequestUri(SPBPLExtensionLicense."Version Check URL");
+        ApiHttpRequestMessage.Method('GET');
 
-        if ApiHttpClient.Send(ApiHttpReqMessage, ApiHttpRespMessage) then begin
-            if ApiHttpRespMessage.IsSuccessStatusCode then begin
-                ApiHttpRespMessage.Content.ReadAs(VersionResponseBody);
+        if ApiHttpClient.Send(ApiHttpRequestMessage, ApiHttpResponseMessage) then begin
+            if ApiHttpResponseMessage.IsSuccessStatusCode then begin
+                ApiHttpResponseMessage.Content.ReadAs(VersionResponseBody);
                 LatestVersion := Version.Create(VersionResponseBody);
                 if (AppInfo.AppVersion < LatestVersion) then begin
-                    SPBExtensionLicense."Update Available" := true;
-                    SPBExtensionLicense.Modify();
+                    SPBPLExtensionLicense."Update Available" := true;
+                    SPBPLExtensionLicense.Modify();
 
-                    OnBeforeVersionCheckUpgradeAvailable(SPBExtensionLicense, LatestVersion, IsHandled);
+                    OnBeforeVersionCheckUpgradeAvailable(SPBPLExtensionLicense, LatestVersion, IsHandled);
                     if IsHandled then
                         exit;
 
                     UserTask.Init();
                     UserTask.Title := StrSubstNo(SubjectTok, AppInfo.Name);
                     UserTask.SetDescription(DocsTok);
-                    if not IsNullGuid(SPBExtensionLicense."Activated By") then
-                        UserTask."Assigned To" := SPBExtensionLicense."Activated By";
+                    if not IsNullGuid(SPBPLExtensionLicense."Activated By") then
+                        UserTask."Assigned To" := SPBPLExtensionLicense."Activated By";
                     UserTask."Due DateTime" := CurrentDateTime;
                     UserTask."Start DateTime" := CurrentDateTime;
                     UserTask."Object Type" := UserTask."Object Type"::Page;
@@ -206,38 +206,38 @@ codeunit 71036 "SPBPL License Management"
                     UserTask.Insert(true);
                 end;
             end else
-                OnAfterVersionCheckFailure(SPBExtensionLicense, ApiHttpRespMessage);
+                OnAfterVersionCheckFailure(SPBPLExtensionLicense, ApiHttpResponseMessage);
         end else
-            OnAfterVersionCheckFailure(SPBExtensionLicense, ApiHttpRespMessage);
+            OnAfterVersionCheckFailure(SPBPLExtensionLicense, ApiHttpResponseMessage);
     end;
 
-    internal procedure DeactivateExtension(var SPBExtensionLicense: Record "SPBPL Extension License"): Boolean
+    internal procedure DeactivateExtension(var SPBPLExtensionLicense: Record "SPBPL Extension License"): Boolean
     var
         DeactivationWarningQst: Label 'This will deactivate this license in this Business Central instance, but you will need to contact the Publisher to release the assigned license. \ \Are you sure you want to deactivate this license?';
     begin
         if Confirm(DeactivationWarningQst, false) then begin
-            SPBExtensionLicense.Validate(Activated, false);
-            SPBExtensionLicense.Modify();
+            SPBPLExtensionLicense.Validate(Activated, false);
+            SPBPLExtensionLicense.Modify();
         end;
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterActivationFailure(var SPBExtensionLicense: Record "SPBPL Extension License"; var AppInfo: ModuleInfo)
+    local procedure OnAfterActivationFailure(var SPBPLExtensionLicense: Record "SPBPL Extension License"; var AppInfo: ModuleInfo)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeVersionCheckUpgradeAvailable(var SPBExtensionLicense: Record "SPBPL Extension License"; var LatestVersion: Version; var IsHandled: Boolean)
+    local procedure OnBeforeVersionCheckUpgradeAvailable(var SPBPLExtensionLicense: Record "SPBPL Extension License"; var LatestVersion: Version; var IsHandled: Boolean)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterActivationSuccess(var SPBExtensionLicense: Record "SPBPL Extension License"; var AppInfo: ModuleInfo)
+    local procedure OnAfterActivationSuccess(var SPBPLExtensionLicense: Record "SPBPL Extension License"; var AppInfo: ModuleInfo)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterVersionCheckFailure(var SPBExtensionLicense: Record "SPBPL Extension License"; var ApiHttpRespMessage: HttpResponseMessage)
+    local procedure OnAfterVersionCheckFailure(var SPBPLExtensionLicense: Record "SPBPL Extension License"; var ApiHttpResponseMessage: HttpResponseMessage)
     begin
     end;
 

--- a/src/codeunit/SPBPLLicenseUtilities.Codeunit.al
+++ b/src/codeunit/SPBPLLicenseUtilities.Codeunit.al
@@ -23,13 +23,13 @@ codeunit 71033 "SPBPL License Utilities"
         exit(SelfTestProductKeyTok);
     end;
 
-    internal procedure LaunchProductUrl(SPBExtensionLicense: Record "SPBPL Extension License")
+    internal procedure LaunchProductUrl(SPBPLExtensionLicense: Record "SPBPL Extension License")
     var
         IsHandled: Boolean;
     begin
-        OnBeforeLaunchProductUrl(SPBExtensionLicense, IsHandled);
+        OnBeforeLaunchProductUrl(SPBPLExtensionLicense, IsHandled);
         if not IsHandled then
-            Hyperlink(SPBExtensionLicense."Product URL");
+            Hyperlink(SPBPLExtensionLicense."Product URL");
     end;
 
     internal procedure AddNameValuePair(var FormData: TextBuilder; name: Text; value: Text)
@@ -43,28 +43,28 @@ codeunit 71033 "SPBPL License Utilities"
         FormData.AppendLine('--SpareBrainedLicensing--');
     end;
 
-    internal procedure UpdateOrCreateIsoStorage(var SPBExtensionLicense: Record "SPBPL Extension License"; ApiResponse: Text)
+    internal procedure UpdateOrCreateIsoStorage(var SPBPLExtensionLicense: Record "SPBPL Extension License"; ApiResponse: Text)
     var
-        SPBIsoStoreManager: Codeunit "SPBPL IsoStore Manager";
+        SPBPLIsoStoreManager: Codeunit "SPBPL IsoStore Manager";
         YesterdayDateTime: DateTime;
     begin
-        SPBIsoStoreManager.SetAppValue(SPBExtensionLicense, 'lastUpdated', Format(CurrentDateTime, 0, 9));
-        SPBIsoStoreManager.SetAppValue(SPBExtensionLicense, 'endDate', Format(SPBExtensionLicense."Subscription End Date", 0, 9));
-        SPBIsoStoreManager.SetAppValue(SPBExtensionLicense, 'active', Format(SPBExtensionLicense.Activated));
+        SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'lastUpdated', Format(CurrentDateTime, 0, 9));
+        SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'endDate', Format(SPBPLExtensionLicense."Subscription End Date", 0, 9));
+        SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'active', Format(SPBPLExtensionLicense.Activated));
 
         // We mark the lastCheckDate as yesterday on activation to trigger one check DURING activation, just to be safe
         // Someone could be installing from an app file that's outdated, etc.
         YesterdayDateTime := CreateDateTime(CalcDate('<-1D>', Today()), Time());
-        SPBIsoStoreManager.SetAppValue(SPBExtensionLicense, 'lastCheckDate', Format(YesterdayDateTime, 0, 9));
+        SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'lastCheckDate', Format(YesterdayDateTime, 0, 9));
 
-        if not SPBIsoStoreManager.ContainsAppValue(SPBExtensionLicense, 'extensionContactEmail') then begin
-            SPBIsoStoreManager.SetAppValue(SPBExtensionLicense, 'extensionContactEmail', SPBExtensionLicense."Billing Support Email");
-            SPBIsoStoreManager.SetAppValue(SPBExtensionLicense, 'extensionMisuseURI', '');
+        if not SPBPLIsoStoreManager.ContainsAppValue(SPBPLExtensionLicense, 'extensionContactEmail') then begin
+            SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'extensionContactEmail', SPBPLExtensionLicense."Billing Support Email");
+            SPBPLIsoStoreManager.SetAppValue(SPBPLExtensionLicense, 'extensionMisuseURI', '');
         end;
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeLaunchProductUrl(var SPBExtensionLicense: Record "SPBPL Extension License"; var IsHandled: Boolean)
+    local procedure OnBeforeLaunchProductUrl(var SPBPLExtensionLicense: Record "SPBPL Extension License"; var IsHandled: Boolean)
     begin
     end;
 }

--- a/src/codeunit/SPBPLLicensingInstall.Codeunit.al
+++ b/src/codeunit/SPBPLLicensingInstall.Codeunit.al
@@ -4,22 +4,22 @@ codeunit 71037 "SPBPL Licensing Install"
 
     trigger OnInstallAppPerDatabase()
     var
-        SPBExtensionLicense: Record "SPBPL Extension License";
-        SPBLicenseUtilities: Codeunit "SPBPL License Utilities";
+        SPBPLExtensionLicense: Record "SPBPL Extension License";
+        SPBPLLicenseUtilities: Codeunit "SPBPL License Utilities";
         AppInfo: ModuleInfo;
     begin
         NavApp.GetCurrentModuleInfo(AppInfo);
         // We install / update the 'Test' entry
-        if not SPBExtensionLicense.Get(AppInfo.Id) then begin
-            SPBExtensionLicense.Init();
-            Evaluate(SPBExtensionLicense."Entry Id", AppInfo.Id);
-            SPBExtensionLicense.Insert();
+        if not SPBPLExtensionLicense.Get(AppInfo.Id) then begin
+            SPBPLExtensionLicense.Init();
+            Evaluate(SPBPLExtensionLicense."Entry Id", AppInfo.Id);
+            SPBPLExtensionLicense.Insert();
         end;
-        SPBExtensionLicense."Extension Name" := AppInfo.Name + ' Test Subcription';
-        SPBExtensionLicense."Product Code" := SPBLicenseUtilities.GetTestProductId();
-        SPBExtensionLicense."Product URL" := 'https://sparebrained.gumroad.com/l/SBILicensingTest';
-        SPBExtensionLicense."Support URL" := 'support@sparebrained.com';
-        SPBExtensionLicense."Billing Support Email" := 'support@sparebrained.com';
-        SPBExtensionLicense.Modify();
+        SPBPLExtensionLicense."Extension Name" := AppInfo.Name + ' Test Subcription';
+        SPBPLExtensionLicense."Product Code" := CopyStr(SPBPLLicenseUtilities.GetTestProductId(), 1, MaxStrLen(SPBPLExtensionLicense."Product Code"));
+        SPBPLExtensionLicense."Product URL" := 'https://sparebrained.gumroad.com/l/SBILicensingTest';
+        SPBPLExtensionLicense."Support URL" := 'support@sparebrained.com';
+        SPBPLExtensionLicense."Billing Support Email" := 'support@sparebrained.com';
+        SPBPLExtensionLicense.Modify();
     end;
 }

--- a/src/page/SPBPLExtensionLicenses.Page.al
+++ b/src/page/SPBPLExtensionLicenses.Page.al
@@ -88,6 +88,7 @@ page 71033 "SPBPL Extension Licenses"
                 Enabled = not Rec.Activated and UserHasWritePermission;
                 Image = SuggestElectronicDocument;
                 Promoted = true;
+                PromotedOnly = true;
                 PromotedCategory = Process;
                 ToolTip = 'Launches the Activation Wizard for this Subscription.';
 
@@ -107,6 +108,7 @@ page 71033 "SPBPL Extension Licenses"
                 Image = Cancel;
                 Promoted = true;
                 PromotedCategory = Process;
+                PromotedOnly = true;
                 ToolTip = 'Forces this Subscription inactive, which will allow entry of a new License Key.';
 
                 trigger OnAction()
@@ -167,13 +169,13 @@ page 71033 "SPBPL Extension Licenses"
 
     local procedure CheckAllForUpdates()
     var
-        SPBLicense: Record "SPBPL Extension License";
-        SPBLicenseMgmt: Codeunit "SPBPL License Management";
+        SPBPLExtensionLicense: Record "SPBPL Extension License";
+        SPBPLLicenseManagement: Codeunit "SPBPL License Management";
     begin
-        if SPBLicense.FindSet(true) then
+        if SPBPLExtensionLicense.FindSet(true) then
             repeat
-                if SPBLicense."Update News URL" <> '' then
-                    SPBLicenseMgmt.DoVersionCheck(SPBLicense);
-            until SPBLicense.Next() = 0;
+                if SPBPLExtensionLicense."Update News URL" <> '' then
+                    SPBPLLicenseManagement.DoVersionCheck(SPBPLExtensionLicense);
+            until SPBPLExtensionLicense.Next() = 0;
     end;
 }

--- a/src/page/SPBPLLicenseActivation.Page.al
+++ b/src/page/SPBPLLicenseActivation.Page.al
@@ -29,7 +29,7 @@ page 71034 "SPBPL License Activation"
 
                         trigger OnDrillDown()
                         begin
-                            SPBLicenseUtilities.LaunchProductUrl(Rec);
+                            SPBPLLicenseUtilities.LaunchProductUrl(Rec);
                         end;
                     }
                 }
@@ -100,7 +100,7 @@ page 71034 "SPBPL License Activation"
 
                     trigger OnDrillDown()
                     begin
-                        LicenseKey := SPBLicenseUtilities.GetTestProductKey();
+                        LicenseKey := SPBPLLicenseUtilities.GetTestProductKey();
                     end;
                 }
             }
@@ -176,8 +176,8 @@ page 71034 "SPBPL License Activation"
     }
 
     var
-        SPBLicenseManagement: Codeunit "SPBPL License Management";
-        SPBLicenseUtilities: Codeunit "SPBPL License Utilities";
+        SPBPLLicenseManagement: Codeunit "SPBPL License Management";
+        SPBPLLicenseUtilities: Codeunit "SPBPL License Utilities";
         LicenseLinkText: Text;
         LicenseKey: Text;
         LicenseFormatHintText: Text;
@@ -238,7 +238,7 @@ page 71034 "SPBPL License Activation"
         // Validation trigger when moving from Step2 to 3
         if (Step = Step::Step2) and not Backwards then begin
             Rec."License Key" := CopyStr(LicenseKey, 1, MaxStrLen(Rec."License Key"));
-            ActivationResult := SPBLicenseManagement.ActivateFromWizard(Rec);
+            ActivationResult := SPBPLLicenseManagement.ActivateFromWizard(Rec);
             Step := Step + 1;
         end;
 

--- a/src/table/SPBPLExtensionLicense.Table.al
+++ b/src/table/SPBPLExtensionLicense.Table.al
@@ -186,8 +186,8 @@ table 71033 "SPBPL Extension License"
 
     internal procedure IsTestSubscription(): Boolean
     var
-        SPBLicenseUtilities: Codeunit "SPBPL License Utilities";
+        SPBPLLicenseUtilities: Codeunit "SPBPL License Utilities";
     begin
-        exit(Rec."Entry Id" = SPBLicenseUtilities.GetTestProductAppId());
+        exit(Rec."Entry Id" = SPBPLLicenseUtilities.GetTestProductAppId());
     end;
 }


### PR DESCRIPTION
I enabled extra analyzers and resolved all the warnings.  Most were just variable naming conventions.  I have left the ruleset I used and the PerTenantExtensionCop and AppSourceCop analyzers enabled.  The ruleset deals with the conflicting conditions between the two analyzers.

Hope this helps.